### PR TITLE
Control whether to dig up

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -200,11 +200,12 @@ minetest.register_abm({
 --
 
 function default.dig_up(pos, node, digger)
-	if digger == nil then return end
-	local np = {x = pos.x, y = pos.y + 1, z = pos.z}
-	local nn = minetest.get_node(np)
-	if nn.name == node.name then
-		minetest.node_dig(np, nn, digger)
+	if digger and not digger:get_player_control().sneak then
+		local np = {x = pos.x, y = pos.y + 1, z = pos.z}
+		local nn = minetest.get_node(np)
+		if nn.name == node.name then
+			minetest.node_dig(np, nn, digger)
+		end
 	end
 end
 


### PR DESCRIPTION
This small change makes it so when the player is holding shift while digging cactus or papyrus it doesn't dig up. This is perfect for making windows in cactus buildings.